### PR TITLE
CI: auto trigger at UTC0 everyday and manual trigger with button

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
   pull_request:
+  # manual trigger
+  workflow_dispatch:
+  # trigger on UTC0 everyday to test on latest nightly toolchain
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   ci:


### PR DESCRIPTION
Testing on nightly toolchain currently is triggered when a commit is pushed or a PR is opened.

But nightly toolchain bumps every night. In this PR, tests will be automatically run on every toolchain via `schedule cron`.

Besides, a manual button is provided via `workflow_dispatch`, like this:
![截图_20250607184504](https://github.com/user-attachments/assets/dcd1f82d-481f-41dd-8845-23fe7885c8cb)
