### PR TITLE
feat: add conversion from AllocError to AxError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,10 @@ page-alloc-64g = []
 page-alloc-4g = []
 page-alloc-256m = []
 
+axerrno = ["dep:axerrno"]
+
 [dependencies]
-axerrno = "0.1"
+axerrno = { version = "0.1", optional = true }
 cfg-if = "1.0"
 rlsf = { version = "0.2", optional = true }
 buddy_system_allocator = { version = "0.10", default-features = false, optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub use tlsf::TlsfByteAllocator;
 use core::alloc::Layout;
 use core::ptr::NonNull;
 
+#[cfg(feature = "axerrno")]
 use axerrno::AxError;
 
 /// The error type used for allocation.
@@ -49,6 +50,7 @@ pub enum AllocError {
     NotAllocated,
 }
 
+#[cfg(feature = "axerrno")]
 impl From<AllocError> for AxError {
     fn from(value: AllocError) -> Self {
         match value {


### PR DESCRIPTION
This PR adds a convenient trait implementation for converting AllocError to AxError.

TODO: make this an optional feature?